### PR TITLE
Fixed NullPointerException bug in AssetService

### DIFF
--- a/src/main/java/com/google/gke/auditor/system/AssetService.java
+++ b/src/main/java/com/google/gke/auditor/system/AssetService.java
@@ -338,8 +338,11 @@ public class AssetService {
             if (pod.getServiceAccount() != null && pod.getServiceAccount().equals(serviceAccount)) {
               Node node = (Node) DetectorUtil
                   .getFromCollection(nodes, pod.getNodeName(), n -> ((Node) n).getNodeName());
-              Dependency dependency = new Dependency(binding, role, serviceAccount, node, pod);
-              dependencies.add(dependency);
+
+              if (node != null) {
+                  Dependency dependency = new Dependency(binding, role, serviceAccount, node, pod);
+                  dependencies.add(dependency);
+              }
             }
           }
         }


### PR DESCRIPTION
This fix refers to issue #2.

Do not allow Dependency objects to be formed when Node is null. 

If allowed, this can cause NullPointerExceptions when handling and filtering Dependencies.