### PR TITLE
Removed bold tags from non-colored messages

### DIFF
--- a/src/main/java/com/google/gke/auditor/system/Logger.java
+++ b/src/main/java/com/google/gke/auditor/system/Logger.java
@@ -356,7 +356,7 @@ public class Logger {
      * Returns the message in the format "Key: value" without coloring.
      */
     public String getMessage() {
-      return (key == null ? "" : Color.DEFAULT_BOLD.code + key + Color.RESET.code + ": ") + value;
+      return (key == null ? "" : key  + ": ") + value;
     }
 
     /**


### PR DESCRIPTION
As suggested in issue #1, bold tags were removed from non-colored messages. This improves readability outside of the terminal. 

E.g. when redirecting tool output to a file, it would look something like this:

	[0;1mExplanation[0m: Kubernetes provides a set of default roles where RBAC is used. Some of these roles such as cluster-admin provide wide-ranging privileges which should only be applied where absolutely necessary. Roles such as cluster-admin allow super-user access to perform any action on any resource. When used in a ClusterRoleBinding, it gives full control over every resource in the cluster and in all namespaces. When used in a RoleBinding, it gives full control over every resource in the RoleBinding's namespace, including the namespace itself.

	[0;1mRemediation[0m: Identify all ClusterRoleBindings to the cluster-admin role. Check if they are used and if they need this role or if they could use a role with fewer privileges. Where possible, first bind users to a lower privileged role and then remove the clusterrolebinding to the cluster-admin role. Care should be taken before removing any clusterrolebindings from the environment to ensure they were not required for operation of the cluster. Specifically, modifications should not be made to clusterrolebindings with the system: prefix as they are required for the operation of system components.

	[0;1mUseful links[0m: [https://kubernetes.io/docs/admin/authorization/rbac/#user-facing-roles]

	[0;1mLevel[0m: VULNERABILITY

	[0;1mSeverity[0m: MEDIUM

By removing the bold tags the readability improves.